### PR TITLE
Removed valueName from text elements

### DIFF
--- a/CustomADMX/SystemCenterEndpointProtection.admx
+++ b/CustomADMX/SystemCenterEndpointProtection.admx
@@ -106,14 +106,14 @@
         <decimal value="0" />
       </disabledValue>
     </policy>
-    <policy name="system_center_endpoint_protection_proxybypass" class="Machine" displayName="$(string.system_center_endpoint_protection_proxybypass)" explainText="$(string.system_center_endpoint_protection_proxybypass_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware" valueName="ProxyBypass" presentation="$(presentation.system_center_endpoint_protection_proxybypass)">
+    <policy name="system_center_endpoint_protection_proxybypass" class="Machine" displayName="$(string.system_center_endpoint_protection_proxybypass)" explainText="$(string.system_center_endpoint_protection_proxybypass_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware" presentation="$(presentation.system_center_endpoint_protection_proxybypass)">
       <parentCategory ref="system_center_endpoint_protection" />
       <supportedOn ref="windows:SUPPORTED_WindowsVista" />
       <elements>
         <text id="system_center_endpoint_protection_proxybypass" valueName="ProxyBypass" required="true" />
       </elements>
     </policy>
-    <policy name="system_center_endpoint_protection_proxyserver" class="Machine" displayName="$(string.system_center_endpoint_protection_proxyserver)" explainText="$(string.system_center_endpoint_protection_proxyserver_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware" valueName="ProxyServer" presentation="$(presentation.system_center_endpoint_protection_proxyserver)">
+    <policy name="system_center_endpoint_protection_proxyserver" class="Machine" displayName="$(string.system_center_endpoint_protection_proxyserver)" explainText="$(string.system_center_endpoint_protection_proxyserver_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware" presentation="$(presentation.system_center_endpoint_protection_proxyserver)">
       <parentCategory ref="system_center_endpoint_protection" />
       <supportedOn ref="windows:SUPPORTED_WindowsVista" />
       <elements>
@@ -886,7 +886,7 @@
         <decimal id="signature_updates_avsignaturedue" valueName="AVSignatureDue" minValue="0" maxValue="4294967295" />
       </elements>
     </policy>
-    <policy name="signature_updates_definitionupdatefilesharessources" class="Machine" displayName="$(string.signature_updates_definitionupdatefilesharessources)" explainText="$(string.signature_updates_definitionupdatefilesharessources_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware\Signature Updates" valueName="DefinitionUpdateFileSharesSources" presentation="$(presentation.signature_updates_definitionupdatefilesharessources)">
+    <policy name="signature_updates_definitionupdatefilesharessources" class="Machine" displayName="$(string.signature_updates_definitionupdatefilesharessources)" explainText="$(string.signature_updates_definitionupdatefilesharessources_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware\Signature Updates" presentation="$(presentation.signature_updates_definitionupdatefilesharessources)">
       <parentCategory ref="signature_updates" />
       <supportedOn ref="windows:SUPPORTED_WindowsVista" />
       <elements>
@@ -923,7 +923,7 @@
         <decimal value="1" />
       </disabledValue>
     </policy>
-    <policy name="signature_updates_fallbackorder" class="Machine" displayName="$(string.signature_updates_fallbackorder)" explainText="$(string.signature_updates_fallbackorder_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware\Signature Updates" valueName="FallbackOrder" presentation="$(presentation.signature_updates_fallbackorder)">
+    <policy name="signature_updates_fallbackorder" class="Machine" displayName="$(string.signature_updates_fallbackorder)" explainText="$(string.signature_updates_fallbackorder_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware\Signature Updates" presentation="$(presentation.signature_updates_fallbackorder)">
       <parentCategory ref="signature_updates" />
       <supportedOn ref="windows:SUPPORTED_WindowsVista" />
       <elements>
@@ -1139,7 +1139,7 @@
         <decimal value="1" />
       </disabledValue>
     </policy>
-    <policy name="ux_configuration_customdefaultactiontoaststring" class="Machine" displayName="$(string.ux_configuration_customdefaultactiontoaststring)" explainText="$(string.ux_configuration_customdefaultactiontoaststring_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware\UX Configuration" valueName="CustomDefaultActionToastString" presentation="$(presentation.ux_configuration_customdefaultactiontoaststring)">
+    <policy name="ux_configuration_customdefaultactiontoaststring" class="Machine" displayName="$(string.ux_configuration_customdefaultactiontoaststring)" explainText="$(string.ux_configuration_customdefaultactiontoaststring_explain)" key="Software\Policies\Microsoft\Microsoft Antimalware\UX Configuration" presentation="$(presentation.ux_configuration_customdefaultactiontoaststring)">
       <parentCategory ref="client_interface" />
       <supportedOn ref="windows:SUPPORTED_WindowsVista" />
       <elements>


### PR DESCRIPTION
Removed `valueName` property from `policy` nodes containing `text` elements.
When both `policy` and `text` have the `valueName` property, policy items within a GPO editor will always show as "Not Configured" even if the value indicated by `valueName` has data.